### PR TITLE
'containers' was accidentally used twice in a sentence instead of 'se…

### DIFF
--- a/Feature/network/sg.md
+++ b/Feature/network/sg.md
@@ -33,7 +33,7 @@ When you launch a container, you associate one or more security groups with the 
 ```
 
 ### Change security groups
-You can update containers to add or remove containers.
+You can update containers to add or remove security groups.
 
 ``` bash
 	$ hyper update --sg-add ssh-sg ssh-container


### PR DESCRIPTION
…curity groups

I know hyper :heartpulse: containers, but this sentence doesn't make sense in its current form