### PR TITLE
fix: update /containers/create/ Entrypoint option to []

### DIFF
--- a/Reference/API/2016-04-04 [Ver. 1.23]/Container/create.md
+++ b/Reference/API/2016-04-04 [Ver. 1.23]/Container/create.md
@@ -26,7 +26,7 @@ Create a container
            "Cmd": [
                    "date"
            ],
-           "Entrypoint": "",
+           "Entrypoint": [],
            "Image": "ubuntu",
            "Labels": {
                    "com.example.vendor": "Acme",


### PR DESCRIPTION
Hi there,

I made a quick PR that resolves #110, updating the Entrypoint value provided in the /containers/create/ API docs from "" to [].

Hope this helps,
Jeff